### PR TITLE
Add sentiment analyzer fetch on load

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -43,6 +43,14 @@ export default function Portfolio() {
   // Sections for navigation
   const sections = ["hero", "about", "skills", "projects", "profiles", "contact"]
 
+  // Call Sentiment Analyzer API on page load
+  useEffect(() => {
+    fetch("https://sentimentanalyzer-y8tk.onrender.com/")
+      .then((res) => res.json())
+      .then((data) => console.log("Sentiment analyzer response:", data))
+      .catch((err) => console.error("Sentiment analyzer fetch error:", err))
+  }, [])
+
   // Close mobile menu when clicking outside
   useEffect(() => {
     function handleClickOutside(event: MouseEvent) {


### PR DESCRIPTION
## Summary
- trigger a request to the sentiment analyzer when the portfolio page loads

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_6859b5e6900c8327a1aacd011e2df319