### PR TITLE
Merge skills into About with responsive grid

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -309,6 +309,42 @@ h2.section-title {
   box-shadow: 0 0 15px rgba(var(--theme-color-rgb), 0.15);
 }
 
+/* Holographic hover effect for skill cards */
+.hover-holographic-effect {
+  position: relative;
+  overflow: hidden;
+  transition: all 0.5s ease;
+}
+
+.hover-holographic-effect::before {
+  content: "";
+  position: absolute;
+  top: -50%;
+  left: -50%;
+  width: 200%;
+  height: 200%;
+  background: linear-gradient(
+    0deg,
+    transparent,
+    transparent 30%,
+    rgba(var(--theme-color-rgb), 0.3)
+  );
+  transform: rotate(-45deg);
+  transition: all 0.5s ease;
+  opacity: 0;
+}
+
+.hover-holographic-effect:hover {
+  transform: scale(1.05);
+  border-color: var(--theme-color-light);
+  box-shadow: 0 0 20px rgba(var(--theme-color-rgb), 0.5);
+}
+
+.hover-holographic-effect:hover::before {
+  opacity: 1;
+  transform: rotate(-45deg) translateY(100%);
+}
+
 /* Animation for decrypt text */
 @keyframes flicker {
   0%,

--- a/app/globals.css
+++ b/app/globals.css
@@ -280,36 +280,7 @@ h2.section-title {
   border-color: var(--theme-color-light);
 }
 
-/* Add these gradient hover effect styles after the existing hover styles */
-.hover-gradient-effect {
-  position: relative;
-  overflow: hidden;
-  transition: all 0.3s ease;
-}
-
-.hover-gradient-effect::before {
-  content: "";
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: linear-gradient(135deg, rgba(var(--theme-color-rgb), 0.05) 0%, rgba(var(--theme-color-rgb), 0.15) 100%);
-  opacity: 0;
-  transition: opacity 0.3s ease;
-  z-index: -1;
-}
-
-.hover-gradient-effect:hover::before {
-  opacity: 1;
-}
-
-.hover-gradient-effect:hover {
-  border-color: var(--theme-color-light);
-  box-shadow: 0 0 15px rgba(var(--theme-color-rgb), 0.15);
-}
-
-/* Holographic hover effect for skill cards */
+/* Holographic hover effect for interactive cards */
 .hover-holographic-effect {
   position: relative;
   overflow: hidden;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -29,7 +29,6 @@ export default function Portfolio() {
 
   // Visibility states for each section
   const [aboutVisible, setAboutVisible] = useState(false)
-  const [skillsVisible, setSkillsVisible] = useState(false)
   const [projectsVisible, setProjectsVisible] = useState(false)
   const [profilesVisible, setProfilesVisible] = useState(false)
   const [contactVisible, setContactVisible] = useState(false)
@@ -41,7 +40,7 @@ export default function Portfolio() {
   const scrollTimeout = useRef<NodeJS.Timeout | null>(null)
 
   // Sections for navigation
-  const sections = ["hero", "about", "skills", "projects", "profiles", "contact"]
+  const sections = ["hero", "about", "projects", "profiles", "contact"]
 
   // Call Sentiment Analyzer API on page load
   const baseUrl = process.env.NEXT_PUBLIC_BASE_API_URL ?? 'https://sentimentanalyzer-y8tk.onrender.com';
@@ -193,9 +192,6 @@ export default function Portfolio() {
               case "about":
                 setAboutVisible(true)
                 break
-              case "skills":
-                setSkillsVisible(true)
-                break
               case "projects":
                 setProjectsVisible(true)
                 break
@@ -211,9 +207,6 @@ export default function Portfolio() {
             switch (sectionId) {
               case "about":
                 setAboutVisible(false)
-                break
-              case "skills":
-                setSkillsVisible(false)
                 break
               case "projects":
                 setProjectsVisible(false)
@@ -318,7 +311,7 @@ export default function Portfolio() {
 
               {/* Navigation */}
               <nav className="hidden md:flex space-x-4 lg:space-x-6">
-                {["about", "skills", "projects", "profiles", "contact"].map((section) => (
+                {["about", "projects", "profiles", "contact"].map((section) => (
                   <button
                     key={section}
                     onClick={() => scrollToSection(section)}
@@ -357,7 +350,7 @@ export default function Portfolio() {
               </div>
 
               {/* Mobile Navigation */}
-              {["home", "about", "skills", "projects", "profiles", "contact"].map((section) => (
+              {["home", "about", "projects", "profiles", "contact"].map((section) => (
                 <button
                   key={section}
                   onClick={() => scrollToSection(section === "home" ? "hero" : section)}
@@ -461,58 +454,55 @@ export default function Portfolio() {
                 </div>
               </div>
             </div>
-          </div>
-        </section>
-
-        {/* Skills Section */}
-        <section id="skills" className="border-t border-theme-30">
-          <div className="container mx-auto px-4">
-            <h2 className="text-xl sm:text-2xl font-bold mb-4 sm:mb-6 flex items-center gap-2 section-title">
-              <span className="text-white">{">"}</span>{" "}
-              {skillsVisible ? (
-                <DecryptText
-                  text={t("skills.title")}
-                  duration={1200}
-                  isVisible={true}
-                  animationColor="text-theme-light"
-                />
-              ) : (
-                t("skills.title")
-              )}
-            </h2>
-            <div className="section-content grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 sm:gap-4">
-              {skillCategories.map((category, index) => (
-                <div
-                  key={index}
-                  className={`border border-theme-30 p-3 rounded-md bg-black/80 opacity-0 hover-gradient-effect ${
-                    skillsVisible ? "animate-fade-in-up" : ""
-                  }`}
-                  style={{
-                    animationDelay: `${index * 150}ms`,
-                    animationFillMode: "forwards",
-                    height: "100%",
-                  }}
-                >
-                  <h3 className="text-white text-base sm:text-lg font-semibold mb-2">{category.title}</h3>
-                  <ul className="space-y-1 text-sm">
-                    {category.items.map((item, itemIndex) => (
-                      <li key={itemIndex} className="flex items-center gap-2">
-                        <span className="text-theme">$</span>{" "}
-                        {skillsVisible ? (
-                          <DecryptText
-                            text={item}
-                            startDelay={itemIndex * 150 + 300}
-                            duration={1500}
-                            isVisible={true}
-                          />
-                        ) : (
-                          item
-                        )}
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-              ))}
+            {/* Skills */}
+            <div className="mt-6">
+              <h3 className="text-lg sm:text-xl font-bold mb-4 sm:mb-6 flex items-center gap-2 section-title">
+                <span className="text-white">{">"}</span>{" "}
+                {aboutVisible ? (
+                  <DecryptText
+                    text={t("skills.title")}
+                    duration={1200}
+                    isVisible={true}
+                    animationColor="text-theme-light"
+                  />
+                ) : (
+                  t("skills.title")
+                )}
+              </h3>
+              <div className="section-content grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-3 sm:gap-4">
+                {skillCategories.map((category, index) => (
+                  <div
+                    key={index}
+                    className={`border border-theme-30 p-3 rounded-md bg-black/80 opacity-0 hover-gradient-effect ${
+                      aboutVisible ? "animate-fade-in-up" : ""
+                    }`}
+                    style={{
+                      animationDelay: `${index * 150}ms`,
+                      animationFillMode: "forwards",
+                      height: "100%",
+                    }}
+                  >
+                    <h4 className="text-white text-base sm:text-lg font-semibold mb-2">{category.title}</h4>
+                    <ul className="space-y-1 text-sm">
+                      {category.items.map((item, itemIndex) => (
+                        <li key={itemIndex} className="flex items-center gap-2">
+                          <span className="text-theme">$</span>{" "}
+                          {aboutVisible ? (
+                            <DecryptText
+                              text={item}
+                              startDelay={itemIndex * 150 + 300}
+                              duration={1500}
+                              isVisible={true}
+                            />
+                          ) : (
+                            item
+                          )}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                ))}
+              </div>
             </div>
           </div>
         </section>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -559,9 +559,9 @@ export default function Portfolio() {
               ].map((project, index) => (
                 <div
                   key={index}
-                  className={`border border-theme-30 p-3 sm:p-4 rounded-md bg-black/80 transition-colors opacity-0 hover-gradient-effect ${
-                    projectsVisible ? "animate-fade-in-up" : ""
-                  }`}
+                    className={`border border-theme-30 p-3 sm:p-4 rounded-md bg-black/80 transition-colors opacity-0 hover-holographic-effect ${
+                      projectsVisible ? "animate-fade-in-up" : ""
+                    }`}
                   style={{
                     animationDelay: `${index * 200}ms`,
                     animationFillMode: "forwards",
@@ -688,9 +688,9 @@ export default function Portfolio() {
                   key={index}
                   target="_blank"
                   download={profile.isDownload}
-                  className={`border border-theme-30 p-3 sm:p-4 rounded-md bg-black/80 transition-colors flex flex-col items-center text-center opacity-0 hover-gradient-effect ${
-                    profilesVisible ? "animate-fade-in-up" : ""
-                  }`}
+                    className={`border border-theme-30 p-3 sm:p-4 rounded-md bg-black/80 transition-colors flex flex-col items-center text-center opacity-0 hover-holographic-effect ${
+                      profilesVisible ? "animate-fade-in-up" : ""
+                    }`}
                   style={{
                     animationDelay: `${index * 150}ms`,
                     animationFillMode: "forwards",

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -473,7 +473,7 @@ export default function Portfolio() {
                 {skillCategories.map((category, index) => (
                   <div
                     key={index}
-                    className={`border border-theme-30 p-3 rounded-md bg-black/80 opacity-0 hover-gradient-effect ${
+                    className={`border border-theme-30 p-3 rounded-md bg-black/80 opacity-0 hover-holographic-effect ${
                       aboutVisible ? "animate-fade-in-up" : ""
                     }`}
                     style={{


### PR DESCRIPTION
## Summary
- combine the former Skills section into About and display skill cards in a responsive 6-column grid on large screens
- remove Skills from navigation and section tracking

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_b_68c41f37b04483279cea9d0e5585d65b