### PR TITLE
feat: add animated explore button

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -371,8 +371,8 @@ h2.section-title {
   height: 3.5rem;
   align-items: center;
   border-radius: 9999px;
-  padding-left: 2rem;
-  padding-right: 2rem;
+  padding-left: 1rem;
+  padding-right: 1rem;
   font-family: Segoe UI, sans-serif;
   font-size: 1.2rem;
   font-weight: 640;

--- a/app/globals.css
+++ b/app/globals.css
@@ -362,3 +362,131 @@ h2.section-title {
     display: none;
   }
 }
+
+/* Explore button styles */
+.explore-button {
+  all: unset;
+  position: relative;
+  display: inline-flex;
+  height: 3.5rem;
+  align-items: center;
+  border-radius: 9999px;
+  padding-left: 2rem;
+  padding-right: 2rem;
+  font-family: Segoe UI, sans-serif;
+  font-size: 1.2rem;
+  font-weight: 640;
+  color: #1d1d1f;
+  letter-spacing: -0.06em;
+  cursor: pointer;
+}
+
+.explore-button-inner,
+.explore-button-inner-hover,
+.explore-button-inner-static {
+  pointer-events: none;
+  display: block;
+}
+
+.explore-button-inner {
+  position: relative;
+}
+
+.explore-button-inner-hover {
+  position: absolute;
+  top: 0;
+  left: 0;
+  opacity: 0;
+  transform: translateY(70%);
+}
+
+.explore-button-inner-static,
+.explore-button-inner-hover {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.explore-button-bg {
+  overflow: hidden;
+  border-radius: 2rem;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  transform: scale(1);
+  transition: transform 1.8s cubic-bezier(0.19, 1, 0.22, 1);
+  border: 1px solid var(--theme-color);
+  background-color: var(--theme-color);
+}
+
+.explore-button-bg,
+.explore-button-bg-layer,
+.explore-button-bg-layers {
+  display: block;
+}
+
+.explore-button-bg-layers {
+  position: absolute;
+  left: 50%;
+  transform: translate(-50%);
+  top: -60%;
+  aspect-ratio: 1 / 1;
+  width: max(200%, 10rem);
+}
+
+.explore-button-bg-layer {
+  border-radius: 9999px;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  transform: scale(0);
+}
+
+.explore-button-bg-layer-1 {
+  background-color: var(--theme-color-light);
+}
+
+.explore-button-bg-layer-2 {
+  background-color: var(--theme-color);
+}
+
+.explore-button-bg-layer-3 {
+  background-color: var(--theme-color-dark);
+}
+
+.explore-button:hover .explore-button-inner-static {
+  opacity: 0;
+  transform: translateY(-70%);
+  transition: transform 1.4s cubic-bezier(0.19, 1, 0.22, 1),
+    opacity 0.3s linear;
+}
+
+.explore-button:hover .explore-button-inner-hover {
+  opacity: 1;
+  transform: translateY(0);
+  transition: transform 1.4s cubic-bezier(0.19, 1, 0.22, 1),
+    opacity 1.4s cubic-bezier(0.19, 1, 0.22, 1);
+}
+
+.explore-button:hover .explore-button-bg-layer {
+  transition: transform 1.3s cubic-bezier(0.19, 1, 0.22, 1),
+    opacity 0.3s linear;
+}
+
+.explore-button:hover .explore-button-bg-layer-1 {
+  transform: scale(1);
+}
+
+.explore-button:hover .explore-button-bg-layer-2 {
+  transition-delay: 0.1s;
+  transform: scale(1);
+}
+
+.explore-button:hover .explore-button-bg-layer-3 {
+  transition-delay: 0.2s;
+  transform: scale(1);
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,7 +6,7 @@ import { useState, useEffect, useRef } from "react"
 import { ArrowRight, Github, Linkedin, ExternalLink, Send, Menu, X } from "lucide-react"
 import Link from "next/link"
 import Image from "next/image"
-import { Button } from "@/components/ui/button"
+import ExploreButton from "@/components/explore-button"
 import { Input } from "@/components/ui/input"
 import { Textarea } from "@/components/ui/textarea"
 import ParticlesBackground from "@/components/particles-background"
@@ -379,12 +379,9 @@ export default function Portfolio() {
               </div>
               <div className="animate-fade-in">
                 <p className="text-base sm:text-xl md:text-2xl text-gray-400 mb-6 sm:mb-8">{t("hero.intro")}</p>
-                <Button
-                  onClick={() => scrollToSection("about")}
-                  className="bg-theme text-black hover:bg-theme-light flex items-center gap-2"
-                >
+                <ExploreButton onClick={() => scrollToSection("about")}>
                   {t("hero.explore")} <ArrowRight className="h-4 w-4" />
-                </Button>
+                </ExploreButton>
               </div>
             </div>
           </div>

--- a/components/explore-button.tsx
+++ b/components/explore-button.tsx
@@ -1,0 +1,29 @@
+import * as React from "react"
+import { cn } from "@/lib/utils"
+
+export interface ExploreButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {}
+
+const ExploreButton = React.forwardRef<HTMLButtonElement, ExploreButtonProps>(
+  ({ className, children, ...props }, ref) => {
+    return (
+      <button ref={ref} className={cn("explore-button", className)} {...props}>
+        <span className="explore-button-bg">
+          <span className="explore-button-bg-layers">
+            <span className="explore-button-bg-layer explore-button-bg-layer-1"></span>
+            <span className="explore-button-bg-layer explore-button-bg-layer-2"></span>
+            <span className="explore-button-bg-layer explore-button-bg-layer-3"></span>
+          </span>
+        </span>
+        <span className="explore-button-inner">
+          <span className="explore-button-inner-static">{children}</span>
+          <span className="explore-button-inner-hover">{children}</span>
+        </span>
+      </button>
+    )
+  }
+)
+
+ExploreButton.displayName = "ExploreButton"
+
+export default ExploreButton


### PR DESCRIPTION
## Summary
- replace hero button with new animated ExploreButton component
- add themed CSS animation for multi-layer hover effect
- introduce reusable ExploreButton component

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: requires interactive ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_b_68c4311ddeb48327bd9ee98a8cb66cec