### PR TITLE
Make about image square with black border

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -445,9 +445,8 @@ export default function Portfolio() {
                 </div>
               </div>
               <div className="md:w-1/3 hidden md:flex justify-center order-1 md:order-2">
-                <div className="relative w-64 h-64 md:w-56 md:h-56 overflow-hidden rounded-full border-2 border-theme-30">
+                <div className="relative w-64 h-64 md:w-56 md:h-56 overflow-hidden border-2 border-black">
                   <Image src="/images/profile-photo.png" alt="Profile Photo" fill className="object-cover" />
-                  <div className="absolute inset-0 border-4 border-theme-10 rounded-full pointer-events-none"></div>
                 </div>
               </div>
             </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -445,7 +445,7 @@ export default function Portfolio() {
                 </div>
               </div>
               <div className="md:w-1/3 hidden md:flex justify-center order-1 md:order-2">
-                <div className="relative w-64 h-64 md:w-56 md:h-56 overflow-hidden border-2 border-black">
+                <div className="relative w-80 h-80 md:w-64 md:h-64 overflow-hidden border-6 border-black">
                   <Image src="/images/profile-photo.png" alt="Profile Photo" fill className="object-cover" />
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- style the about-section profile image as a square with a black border

## Testing
- `npm run lint` *(fails: prompts for ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_b_68c439b185c483278c9ac584010061a7